### PR TITLE
Don't use internal linkage for function templates

### DIFF
--- a/ZividOpenCV/ZDF2OpenCV/ZDF2OpenCV.cpp
+++ b/ZividOpenCV/ZDF2OpenCV/ZDF2OpenCV.cpp
@@ -21,34 +21,34 @@ enum class Axis
 };
 
 template<Axis axis>
-static float getValue(const Zivid::Point &p);
+float getValue(const Zivid::Point &p);
 
 template<>
-static float getValue<Axis::X>(const Zivid::Point &p)
+float getValue<Axis::X>(const Zivid::Point &p)
 {
     return p.x;
 }
 
 template<>
-static float getValue<Axis::Y>(const Zivid::Point &p)
+float getValue<Axis::Y>(const Zivid::Point &p)
 {
     return p.y;
 }
 
 template<>
-static float getValue<Axis::Z>(const Zivid::Point &p)
+float getValue<Axis::Z>(const Zivid::Point &p)
 {
     return p.z;
 }
 
 template<Axis axis>
-static bool isLesserOrNan(const Zivid::Point &a, const Zivid::Point &b)
+bool isLesserOrNan(const Zivid::Point &a, const Zivid::Point &b)
 {
     return getValue<axis>(a) < getValue<axis>(b) ? true : std::isnan(getValue<axis>(a));
 }
 
 template<Axis axis>
-static bool isGreaterOrNaN(const Zivid::Point &a, const Zivid::Point &b)
+bool isGreaterOrNaN(const Zivid::Point &a, const Zivid::Point &b)
 {
     return getValue<axis>(a) > getValue<axis>(b) ? true : std::isnan(getValue<axis>(a));
 }


### PR DESCRIPTION
Clang gave me this error:

    explicit template specialization cannot have a storage class

It can be fixed by just removing `static` from the specializations, but
I don't understand why any of these were declared static in the first
place, so let's just remove it entirely.