### PR TITLE
Add building of samples in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ jobs:
     matrix:
       Ubuntu1804:
         os: 'ubuntu:18.04'
-        command: './test.sh'
+        command: './lint.sh && ./build.sh'
   steps:
   - script: docker run
               --volume $PWD:/host

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,11 +6,11 @@ jobs:
     matrix:
       Ubuntu1804:
         os: 'ubuntu:18.04'
-        command: './lint.sh'
+        command: './test.sh'
   steps:
   - script: docker run
               --volume $PWD:/host
               --workdir /host/continuous-integration/linux
               $(os)
               bash -c "./setup.sh && $(command)"
-    displayName: 'Lint'
+    displayName: 'Test'

--- a/continuous-integration/linux/build.sh
+++ b/continuous-integration/linux/build.sh
@@ -3,8 +3,6 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR=$(realpath "$SCRIPT_DIR/../..")
 
-"$SCRIPT_DIR/lint.sh"
-
 cd $ROOT_DIR
 mkdir build || exit $?
 cd build || exit $?

--- a/continuous-integration/linux/platform-dependent/ubuntu-18.04/setup.sh
+++ b/continuous-integration/linux/platform-dependent/ubuntu-18.04/setup.sh
@@ -12,5 +12,20 @@ apt-yes dist-upgrade || exit $?
 apt-yes install \
     clang-8 \
     clang-format-8 \
+    cmake \
+    libpcl-dev \
     wget \
     || exit $?
+
+function install_www_deb {
+    TMP_DIR=$(mktemp --tmpdir --directory install_www_deb-XXXX) || exit $?
+    pushd $TMP_DIR || exit $?
+    wget -q "$@" || exit $?
+    echo "Installing Zivid debian package $1"
+    apt-yes install --fix-broken ./*deb || exit $?
+    popd || exit $?
+    rm -r $TMP_DIR || exit $?
+}
+
+install_www_deb https://www.zivid.com/hubfs/softwarefiles/releases/1.5.0+63f281e2-26/u18/zivid-telicam-driver_2.0.0.1-1_amd64.deb || exit $?
+install_www_deb https://www.zivid.com/hubfs/softwarefiles/releases/1.5.0+63f281e2-26/u18/zivid_1.5.0+63f281e2-26_amd64.deb || exit $?

--- a/continuous-integration/linux/test.sh
+++ b/continuous-integration/linux/test.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR=$(realpath "$SCRIPT_DIR/../..")
+
+"$SCRIPT_DIR/lint.sh"
+
+cd $ROOT_DIR
+mkdir build || exit $?
+cd build || exit $?
+cmake -DCMAKE_CXX_COMPILER=clang++-8 \
+    -DUSE_EIGEN3=OFF \
+    -DUSE_OPENCV=OFF \
+    -DUSE_VIS3D=OFF \
+    .. || exit $?
+cmake --build . || exit $?


### PR DESCRIPTION
I'm currently only building a subset of the samples which was easy to
get to build. Still, this will ensure those samples build, that cmake
works etc. Then we can expand with the OpenCV and Eigen samples later.