### PR TITLE
Size() constructor inverted row column

### DIFF
--- a/ZividOpenCV/CaptureUndistortRGB/CaptureUndistortRGB.cpp
+++ b/ZividOpenCV/CaptureUndistortRGB/CaptureUndistortRGB.cpp
@@ -113,8 +113,8 @@ cv::Mat pointCloudToRGB(const Zivid::PointCloud &pointCloud)
 
 std::tuple<cv::Mat, cv::Mat> reformatCameraIntrinsics(const Zivid::CameraIntrinsics &cameraIntrinsics)
 {
-    cv::Mat distortionCoefficients(cv::Size(1, 5), CV_64FC1, cv::Scalar(0));
-    cv::Mat cameraMatrix(cv::Size(3, 3), CV_64FC1, cv::Scalar(0));
+    cv::Mat distortionCoefficients(1, 5, CV_64FC1, cv::Scalar(0));
+    cv::Mat cameraMatrix(3, 3, CV_64FC1, cv::Scalar(0));
 
     distortionCoefficients.at<double>(0, 0) = cameraIntrinsics.distortion().k1().value();
     distortionCoefficients.at<double>(0, 1) = cameraIntrinsics.distortion().k2().value();


### PR DESCRIPTION
If you run the original code in debug mode you will get an assertion failure. 
`CV_DbgAssert((unsigned)(i1 * DataType<_Tp>::channels) < (unsigned)(size.p[1] * channels()));`
This is because as the Mat::Mat constructor documentation puts it:

> size – 2D array size: Size(cols, rows) . In the Size() constructor, the number of rows and the number of columns go in the reverse order.