### PR TITLE
Add 2D API to CaptureUndistortRGB example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Check out our [tutorial on configuring and building these samples on Ubuntu](htt
 
 - [**ZividOpenCV**](https://github.com/zivid/cpp-extra-samples/tree/master/ZividOpenCV)
 	- [**ZDF2OpenCV**](https://github.com/zivid/cpp-extra-samples/blob/master/ZividOpenCV/ZDF2OpenCV/ZDF2OpenCV.cpp) - Import a ZDF point cloud and convert it to OpenCV format.
-	- [**CaptureUndistortRGB**](https://github.com/zivid/cpp-extra-samples/blob/master/ZividOpenCV/ZDF2OpenCV/CaptureUndistortRGB.cpp) - Undistort an RGB image from a ZDF point cloud using Zivid camera intrinsics.
+	- [**CaptureUndistortRGB**](https://github.com/zivid/cpp-extra-samples/blob/master/ZividOpenCV/CaptureUndistortRGB/CaptureUndistortRGB.cpp) - Use Zivid camera intrinsics to undistort an RGB image. This example will prompt the user for whether to capture a 2D or a 3D image. In both instances it will operate on a 2D image. However, in the 3D case it will extract 2D image from a ZDF point cloud. The 2D variant is faster.
 	- **Dependencies:**
-		- [OpenCV](https://opencv.org/) version 4.0.1-dev or newer
+		- [OpenCV](https://opencv.org/) version 4.0.1 or newer
 
 - [**HandEyeCalibration**](https://github.com/zivid/cpp-extra-samples/tree/master/HandEyeCalibration)
 	- [**UtilizeEyeInHandCalibration**](https://github.com/zivid/cpp-extra-samples/blob/master/HandEyeCalibration/UtilizeEyeInHandCalibration/UtilizeEyeInHandCalibration.cpp) - Transform a 3D point from camera frame to robot base frame using hand-eye calibration matrix.

--- a/ZividOpenCV/CaptureUndistortRGB/CaptureUndistortRGB.cpp
+++ b/ZividOpenCV/CaptureUndistortRGB/CaptureUndistortRGB.cpp
@@ -1,5 +1,5 @@
 /*
-Undistort an RGB image from a ZDF point cloud using Zivid camera intrinsics.
+Undistort a BGR image from a ZDF point cloud using Zivid camera intrinsics.
 */
 
 #include <Zivid/CloudVisualizer.h>
@@ -12,9 +12,13 @@ Undistort an RGB image from a ZDF point cloud using Zivid camera intrinsics.
 
 #include <iostream>
 
-cv::Mat pointCloudToRGB(const Zivid::PointCloud &);
+cv::Mat pointCloudToBGR(const Zivid::PointCloud &);
+cv::Mat imageToBGR(const Zivid::Image<Zivid::RGBA8> &);
 std::tuple<cv::Mat, cv::Mat> reformatCameraIntrinsics(const Zivid::CameraIntrinsics &);
-void displayRGB(const cv::Mat &, const std::string &);
+void displayBGR(const cv::Mat &, const std::string &);
+std::string getInput(void);
+cv::Mat getImage2D(Zivid::Camera &camera);
+cv::Mat getImage3D(Zivid::Camera &camera, Zivid::Application &zivid);
 
 int main()
 {
@@ -25,60 +29,46 @@ int main()
         std::cout << "Connecting to the camera" << std::endl;
         auto camera = zivid.connectCamera();
 
-        std::cout << "Configuring the camera settings" << std::endl;
-        camera << Zivid::Settings::Iris{ 21 } << Zivid::Settings::ExposureTime{ std::chrono::microseconds{ 20000 } }
-               << Zivid::Settings::Gain{ 1 } << Zivid::Settings::Brightness{ 1.0 };
+        std::cout << "Enter \"2d\" or \"3d\" to select mode, then press Enter/Return to confirm" << std::endl;
+        const auto command = getInput();
+        bool use2D = false;
+        if(command == "2d" || command == "2D")
+        {
+            use2D = true;
+        }
 
-        std::cout << "Capturing a frame" << std::endl;
-        const auto frame = camera.capture();
+        const auto bgr = (use2D ? getImage2D(camera) : getImage3D(camera, zivid));
 
-        std::cout << "Setting up visualization" << std::endl;
-        Zivid::CloudVisualizer vis;
-        zivid.setDefaultComputeDevice(vis.computeDevice());
-
-        std::cout << "Displaying the point cloud" << std::endl;
-        vis.showMaximized();
-        vis.show(frame);
-        vis.resetToFit();
-
-        std::cout << "Running the visualizer. Blocking until the window closes" << std::endl;
-        vis.run();
-
-        std::cout << "Converting ZDF point cloud to OpenCV format" << std::endl;
-
-        const auto pointCloud = frame.getPointCloud();
-        const auto rgb = pointCloudToRGB(pointCloud);
-
-        std::cout << "Undistorting the RGB image" << std::endl;
+        std::cout << "Undistorting the BGR image" << std::endl;
 
         const auto cameraIntrinsticsCV = reformatCameraIntrinsics(camera.intrinsics());
         const auto distortionCoefficients = std::get<0>(cameraIntrinsticsCV);
         const auto cameraMatrix = std::get<1>(cameraIntrinsticsCV);
 
-        const auto size = rgb.size();
+        const auto size = bgr.size();
         const auto optimalCameraMatrix =
             cv::getOptimalNewCameraMatrix(cameraMatrix, distortionCoefficients, size, 1, size);
 
-        cv::Mat rgbUndistorted;
-        cv::Mat rgbUndistortedFull;
+        cv::Mat bgrUndistorted;
+        cv::Mat bgrUndistortedFull;
 
-        cv::undistort(rgb, rgbUndistorted, cameraMatrix, distortionCoefficients);
-        cv::undistort(rgb, rgbUndistortedFull, cameraMatrix, distortionCoefficients, optimalCameraMatrix);
+        cv::undistort(bgr, bgrUndistorted, cameraMatrix, distortionCoefficients);
+        cv::undistort(bgr, bgrUndistortedFull, cameraMatrix, distortionCoefficients, optimalCameraMatrix);
 
-        std::cout << "Displaying and saving the RGB image" << std::endl;
+        std::cout << "Displaying and saving the BGR image" << std::endl;
 
-        displayRGB(rgb, "Distorted RGB image");
-        cv::imwrite("Distorted RGB image.jpg", rgb);
+        displayBGR(bgr, "Distorted BGR image");
+        cv::imwrite("Distorted RGB image.jpg", bgr);
 
-        std::cout << "Displaying and saving the undistorted RGB image" << std::endl;
+        std::cout << "Displaying and saving the undistorted BGR image" << std::endl;
 
-        displayRGB(rgbUndistorted, "Undistorted RGB image");
-        cv::imwrite("Undistorted RGB image.jpg", rgbUndistorted);
+        displayBGR(bgrUndistorted, "Undistorted BGR image");
+        cv::imwrite("Undistorted RGB image.jpg", bgrUndistorted);
 
-        std::cout << "Displaying and saving the Undistorted RGB image - full" << std::endl;
+        std::cout << "Displaying and saving the Undistorted BGR image - full" << std::endl;
 
-        displayRGB(rgbUndistortedFull, "Undistorted RGB image - full");
-        cv::imwrite("Undistorted RGB image - full.jpg", rgbUndistorted);
+        displayBGR(bgrUndistortedFull, "Undistorted BGR image - full");
+        cv::imwrite("Undistorted RGB image - full.jpg", bgrUndistorted);
     }
     catch(const std::exception &e)
     {
@@ -87,9 +77,82 @@ int main()
     }
 }
 
-cv::Mat pointCloudToRGB(const Zivid::PointCloud &pointCloud)
+cv::Mat getImage3D(Zivid::Camera &camera, Zivid::Application &zivid)
 {
-    cv::Mat rgb(static_cast<int>(pointCloud.height()),
+    std::cout << "3D mode" << std::endl;
+
+    std::cout << "Configuring the camera settings" << std::endl;
+    camera << Zivid::Settings::Iris{ 21 } << Zivid::Settings::ExposureTime{ std::chrono::microseconds{ 20000 } }
+           << Zivid::Settings::Gain{ 1 } << Zivid::Settings::Brightness{ 1.0 };
+
+    std::cout << "Capturing a 3D frame" << std::endl;
+    const auto frame = camera.capture();
+
+    std::cout << "Setting up visualization" << std::endl;
+    Zivid::CloudVisualizer vis;
+    zivid.setDefaultComputeDevice(vis.computeDevice());
+
+    std::cout << "Displaying the point cloud" << std::endl;
+    vis.showMaximized();
+    vis.show(frame);
+    vis.resetToFit();
+
+    std::cout << "Running the visualizer. Blocking until the window closes" << std::endl;
+    vis.run();
+
+    std::cout << "Converting ZDF point cloud to OpenCV format" << std::endl;
+    const auto pointCloud = frame.getPointCloud();
+
+    return pointCloudToBGR(pointCloud);
+}
+
+cv::Mat getImage2D(Zivid::Camera &camera)
+{
+    std::cout << "2D mode" << std::endl;
+
+    std::cout << "Configuring the camera settings" << std::endl;
+    Zivid::Settings2D settings = Zivid::Settings2D();
+    settings.set(Zivid::Settings2D::ExposureTime{ std::chrono::microseconds{ 10000 } });
+    settings.set(Zivid::Settings2D::Gain{ 2.0 });
+    settings.set(Zivid::Settings2D::Iris{ 27 });
+    settings.set(Zivid::Settings2D::Brightness{ 1.0 });
+
+    std::cout << "Capturing a 2D frame" << std::endl;
+    const auto frame = camera.capture2D(settings);
+
+    std::cout << "Getting RGBA8 image from 2D frame" << std::endl;
+    const auto image = frame.image<Zivid::RGBA8>();
+
+    std::cout << "Converting RGBA8 image to OpenCV format" << std::endl;
+
+    return imageToBGR(image);
+}
+
+std::string getInput()
+{
+    std::string command;
+    std::getline(std::cin, command);
+    return command;
+}
+
+cv::Mat imageToBGR(const Zivid::Image<Zivid::RGBA8> &image)
+{
+    // The cast for image.dataPtr() is required because the cv::Mat constructor requires non-const void *.
+    // It does not actually mutate the data, it only adds an OpenCV header to the matrix. We then protect
+    // our own instance with const.
+    const cv::Mat rgbaMat(image.height(),
+                          image.width(),
+                          CV_8UC4,
+                          const_cast<void *>(static_cast<const void *>(image.dataPtr())));
+    cv::Mat bgr;
+    cv::cvtColor(rgbaMat, bgr, cv::COLOR_RGBA2BGR);
+
+    return bgr;
+}
+
+cv::Mat pointCloudToBGR(const Zivid::PointCloud &pointCloud)
+{
+    cv::Mat bgr(static_cast<int>(pointCloud.height()),
                 static_cast<int>(pointCloud.width()),
                 CV_8UC3,
                 cv::Scalar(0, 0, 0));
@@ -101,14 +164,14 @@ cv::Mat pointCloudToRGB(const Zivid::PointCloud &pointCloud)
     {
         for(int j = 0; j < width; j++)
         {
-            cv::Vec3b &color = rgb.at<cv::Vec3b>(i, j);
+            cv::Vec3b &color = bgr.at<cv::Vec3b>(i, j);
             color[0] = pointCloud(i, j).blue();
             color[1] = pointCloud(i, j).green();
             color[2] = pointCloud(i, j).red();
         }
     }
 
-    return rgb;
+    return bgr;
 }
 
 std::tuple<cv::Mat, cv::Mat> reformatCameraIntrinsics(const Zivid::CameraIntrinsics &cameraIntrinsics)
@@ -131,9 +194,9 @@ std::tuple<cv::Mat, cv::Mat> reformatCameraIntrinsics(const Zivid::CameraIntrins
     return std::make_tuple(distortionCoefficients, cameraMatrix);
 }
 
-void displayRGB(const cv::Mat &rgb, const std::string &rgbName)
+void displayBGR(const cv::Mat &bgr, const std::string &bgrName)
 {
-    cv::namedWindow(rgbName, cv::WINDOW_AUTOSIZE);
-    cv::imshow(rgbName, rgb);
+    cv::namedWindow(bgrName, cv::WINDOW_AUTOSIZE);
+    cv::imshow(bgrName, bgr);
     cv::waitKey(0);
 }


### PR DESCRIPTION
The last two commits represent two alternative approaches to a combined example.
fe39a35: Use #define to select whether to use 2D or 3D APIs
9698d44: Use std::getline() to prompt user to select 2D or 3D (actual implementation defaults to 3D after 5 seconds.