### PR TITLE
CI: Use correct source and build dirs

### DIFF
--- a/continuous-integration/linux/build.sh
+++ b/continuous-integration/linux/build.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ROOT_DIR=$(realpath "$SCRIPT_DIR/../../source")
+ROOT_DIR=$(realpath "$SCRIPT_DIR/../..")
+SOURCE_DIR="$ROOT_DIR/source"
 BUILD_ROOT_DIR="$ROOT_DIR/build/ci"
 
 #There's a C++11 compatibility bug in the Zivid API which makes it fail on
@@ -36,7 +37,7 @@ function build()
         -DWARNINGS=ON \
         -DWARNINGS_AS_ERRORS=ON \
         "$OS_SPECIFIC_OPTIONS" \
-        ../../.. || exit $?
+        "$SOURCE_DIR" || exit $?
     cmake --build . || exit $?
 }
 

--- a/continuous-integration/linux/lint.sh
+++ b/continuous-integration/linux/lint.sh
@@ -2,9 +2,10 @@
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR=$(realpath "$SCRIPT_DIR/../..")
+SOURCE_DIR="$ROOT_DIR/source"
 
-cppFiles=$(find "$ROOT_DIR" -name '*.cpp')
-hFiles=$(find "$ROOT_DIR" -name '*.h')
+cppFiles=$(find "$SOURCE_DIR" -name '*.cpp')
+hFiles=$(find "$SOURCE_DIR" -name '*.h')
 
 if [ -z "$cppFiles" ]; then
     echo Error: Cannot find C++ source files


### PR DESCRIPTION
`build.sh` used to build in the directory `/source/build` relative to the
repo root. Now we instead build in `/build` relative to the repo root.
This was the intention all along, the previous was just a bug.

`lint.sh` used to look for files in the entire repo. It now only looks in
the `source` folder, in order to avoid finding generated files in the
`build` folder.

This fixes #65