### PR TITLE
More useful error message for clang-format errors

### DIFF
--- a/continuous-integration/linux/lint.sh
+++ b/continuous-integration/linux/lint.sh
@@ -12,10 +12,20 @@ if [ -z "$cppFiles" ]; then
     exit 1
 fi
 
+echo "Checking formatting"
+errorsFound=0
 for fileName in $cppFiles $hFiles; do
     echo $fileName
-    diff $fileName \
-        <(clang-format-8 $fileName) \
-        || exit $?
+    diff $fileName <(clang-format-8 $fileName)
+    if [ $? -ne 0 ]; then
+        let "errorsFound=errorsFound+1"
+    else
+        echo "ok"
+    fi
 done
-echo Success! ["$0"]
+echo
+if [ $errorsFound -ne 0 ]; then
+    echo "ERROR: $errorsFound formatting error(s) found! See the diffs for each file printed above."
+    exit 1
+fi
+echo "All files are properly formatted!" ["$0"]


### PR DESCRIPTION
Fixes #75

Example when an error is found now:
```
(...)
/home/knatten/code/cpp-extra-samples/source/Camera/Basic/Capture/Capture.cpp
ok
/home/knatten/code/cpp-extra-samples/source/Camera/Basic/Capture2D/Capture2D.cpp
ok
/home/knatten/code/cpp-extra-samples/source/Camera/InfoUtilOther/GetCameraIntrinsics/GetCameraIntrinsics.cpp
17,18c17
<     
<             std::cout << "Connecting to the camera" << std::endl;
---
>         std::cout << "Connecting to the camera" << std::endl;
/home/knatten/code/cpp-extra-samples/source/Camera/InfoUtilOther/CameraUserData/CameraUserData.cpp
ok

ERROR: 1 formatting error(s) found! See the diffs for each file printed above.

```

I'm sure this could be improved even further, but this hopefully at least makes the situation better for now.