### PR TITLE
Add file camera to the repository

### DIFF
--- a/source/Applications/Basic/Visualization/CaptureFromFileVis3D/CaptureFromFileVis3D.cpp
+++ b/source/Applications/Basic/Visualization/CaptureFromFileVis3D/CaptureFromFileVis3D.cpp
@@ -16,7 +16,7 @@ int main()
         Zivid::CloudVisualizer vis;
         zivid.setDefaultComputeDevice(vis.computeDevice());
 
-        auto zdfFile = Zivid::Environment::dataPath() + "/MiscObjects.zdf";
+        auto zdfFile = "MiscObjects.zdf";
 
         std::cout << "Initializing camera emulation using file: " << zdfFile << std::endl;
         auto camera = zivid.createFileCamera(zdfFile);

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -90,6 +90,9 @@ add_custom_target(
     COMMAND ${CMAKE_COMMAND} -E copy
             ${CMAKE_CURRENT_SOURCE_DIR}/Zivid3D.zdf
             ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}
+    COMMAND ${CMAKE_COMMAND} -E copy
+            ${CMAKE_CURRENT_SOURCE_DIR}/MiscObjects.zdf
+            ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}
 )
 
 if(WIN32)

--- a/source/Camera/Basic/CaptureFromFile/CaptureFromFile.cpp
+++ b/source/Camera/Basic/CaptureFromFile/CaptureFromFile.cpp
@@ -10,7 +10,7 @@ int main()
     {
         Zivid::Application zivid;
 
-        auto zdfFile = Zivid::Environment::dataPath() + "/MiscObjects.zdf";
+        auto zdfFile = "MiscObjects.zdf";
         auto resultFile = "result.zdf";
 
         std::cout << "Initializing camera emulation using file: " << zdfFile << std::endl;


### PR DESCRIPTION
This commit simplifies running file camera samples. For Ubuntu, it was required to download the file camera (MiscObjects.zdf) from the Zivid website.

Fixes #94 