### PR TITLE
Fix OpenCV version

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ There are two main categories of samples: **Camera** and **Applications**. The s
         - [Eigen](http://eigen.tuxfamily.org/) version 3.3.7 or newer
     - [**CaptureUndistortRGB**][CaptureUndistortRGB-url] - Use Zivid camera intrinsics to undistort an RGB image. This example will prompt the user for whether to capture a 2D or a 3D image. In both instances it will operate on a 2D image. However, in the 3D case it will extract 2D image from a ZDF point cloud. The 2D variant is faster.
       - **Dependencies:**
-        - [OpenCV](https://opencv.org/) version 4.0.1 or newer
+        - [OpenCV](https://opencv.org/) version 4.1.0 or newer
     - [**CreateDepthMap**][CreateDepthMap-url] - Import a ZDF point cloud and convert it to OpenCV format, then extract and visualize depth map.
       - **Dependencies:**
-        - [OpenCV](https://opencv.org/) version 4.0.1 or newer
+        - [OpenCV](https://opencv.org/) version 4.1.0 or newer
 
 ## Instructions
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -77,7 +77,7 @@ else()
 endif()
 
 if(USE_OPENCV)
-    find_package(OpenCV 4.0.1 COMPONENTS core highgui calib3d)
+    find_package(OpenCV 4.1.0 COMPONENTS core highgui calib3d)
     if(NOT OpenCV_FOUND)
         message(FATAL_ERROR "OpenCV not found. Please point OpenCV_DIR to the directory of your OpenCV installation (containing the file OpenCVConfig.cmake), or disable the OpenCV samples  with -DUSE_OPENCV=OFF.")
     endif()


### PR DESCRIPTION
Fixes #74 

The correct version is 4.1.0. actually (not 4.0.1. or 4.1.1)

KB is fixed: https://zivid.atlassian.net/wiki/spaces/ZividKB/pages/61472793
