### PR TITLE
Move files to zivid data

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ There are two main categories of samples: **Camera** and **Applications**. The s
 
 [**Install Zivid Software**](https://zivid.atlassian.net/wiki/spaces/ZividKB/pages/59080712/Zivid+Software+Installation).
 Note: The version tested with Zivid cameras is 1.8.0.
+[**Download Zivid Sample Data**](https://zivid.atlassian.net/wiki/spaces/ZividKB/pages/450363393/Sample+Data).
 
 ### Windows
 

--- a/source/Applications/Advanced/CaptureUndistortRGB/CaptureUndistortRGB.cpp
+++ b/source/Applications/Advanced/CaptureUndistortRGB/CaptureUndistortRGB.cpp
@@ -58,17 +58,17 @@ int main()
         std::cout << "Displaying and saving the BGR image" << std::endl;
 
         displayBGR(bgr, "Distorted BGR image");
-        cv::imwrite("Distorted RGB image.jpg", bgr);
+        cv::imwrite("ImageDistorted.jpg", bgr);
 
         std::cout << "Displaying and saving the undistorted BGR image" << std::endl;
 
         displayBGR(bgrUndistorted, "Undistorted BGR image");
-        cv::imwrite("Undistorted RGB image.jpg", bgrUndistorted);
+        cv::imwrite("ImageUndistorted.jpg", bgrUndistorted);
 
         std::cout << "Displaying and saving the Undistorted BGR image - full" << std::endl;
 
         displayBGR(bgrUndistortedFull, "Undistorted BGR image - full");
-        cv::imwrite("Undistorted RGB image - full.jpg", bgrUndistorted);
+        cv::imwrite("ImageUndistortedFull.jpg", bgrUndistorted);
     }
     catch(const std::exception &e)
     {

--- a/source/Applications/Advanced/Downsample/Downsample.cpp
+++ b/source/Applications/Advanced/Downsample/Downsample.cpp
@@ -23,7 +23,7 @@ int main()
     {
         Zivid::Application zivid;
 
-        std::string filename = "Zivid3D.zdf";
+        std::string filename = Zivid::Environment::dataPath() + "/Zivid3D.zdf";
         std::cout << "Reading " << filename << " point cloud" << std::endl;
         Zivid::Frame frame(filename);
 

--- a/source/Applications/Advanced/HandEyeCalibration/PoseConversions/PoseConversions.cpp
+++ b/source/Applications/Advanced/HandEyeCalibration/PoseConversions/PoseConversions.cpp
@@ -8,10 +8,11 @@ This example shows how to use Eigen to convert to and from:
  It provides convenience functions that can be reused in applicable applications.
 */
 
+#include <Zivid/Zivid.h>
+
 #include <Eigen/Core>
 #include <Eigen/Dense>
 #include <Eigen/Geometry>
-#include <Zivid/Zivid.h>
 
 #include <opencv2/core/core.hpp>
 #include <opencv2/core/eigen.hpp>

--- a/source/Applications/Advanced/HandEyeCalibration/PoseConversions/PoseConversions.cpp
+++ b/source/Applications/Advanced/HandEyeCalibration/PoseConversions/PoseConversions.cpp
@@ -11,6 +11,7 @@ This example shows how to use Eigen to convert to and from:
 #include <Eigen/Core>
 #include <Eigen/Dense>
 #include <Eigen/Geometry>
+#include <Zivid/Zivid.h>
 
 #include <opencv2/core/core.hpp>
 #include <opencv2/core/eigen.hpp>
@@ -62,7 +63,8 @@ int main()
         Eigen::IOFormat vectorFormatRules(4, 0, ", ", "", "", "", "[", "]");
         printHeader("This example shows conversions to/from Transformation Matrix");
 
-        const auto transformationMatrix = getTransformationMatrixFromYAML("robotTransform.yaml");
+        const auto transformationMatrix =
+            getTransformationMatrixFromYAML(Zivid::Environment::dataPath() + "/RobotTransform.yaml");
         std::cout << transformationMatrix.matrix().format(matrixFormatRules) << std::endl;
 
         // Extract Rotation Matrix and Translation Vector from Transformation Matrix
@@ -101,7 +103,7 @@ int main()
         // Combine Rotation Matrix with Translation Vector to form Transformation Matrix
         Eigen::Affine3d transformationMatrixFromQuaternion(rotationMatrixFromQuaternion);
         transformationMatrixFromQuaternion.translation() = transformationMatrix.translation();
-        saveTransformationMatrixToYAML(transformationMatrixFromQuaternion, "robotTransformOut.yaml");
+        saveTransformationMatrixToYAML(transformationMatrixFromQuaternion, "RobotTransformOut.yaml");
     }
 
     catch(const std::exception &e)

--- a/source/Applications/Advanced/HandEyeCalibration/UtilizeEyeInHandCalibration/UtilizeEyeInHandCalibration.cpp
+++ b/source/Applications/Advanced/HandEyeCalibration/UtilizeEyeInHandCalibration/UtilizeEyeInHandCalibration.cpp
@@ -4,6 +4,7 @@ coordinates from the camera frame to the robot base frame.
 */
 
 #include <Eigen/Core>
+#include <Zivid/Zivid.h>
 #include <opencv2/core/core.hpp>
 
 #include <cmath>
@@ -21,10 +22,10 @@ int main()
         std::cout << "Point coordinates in camera frame: " << pointInCameraFrame.segment(0, 3).transpose() << std::endl;
 
         // Read camera pose in end-effector frame (result of eye-in-hand calibration)
-        const auto eyeInHandTransformation = readTransform("handEyeTransform.yaml");
+        const auto eyeInHandTransformation = readTransform(Zivid::Environment::dataPath() + "/EyeInHandTransform.yaml");
 
         // Read end-effector pose in robot base frame
-        const auto endEffectorPose = readTransform("robotTransform.yaml");
+        const auto endEffectorPose = readTransform(Zivid::Environment::dataPath() + "/RobotTransform.yaml");
 
         // convert to Eigen matrices for easier computation
         const auto transformEndEffectorToCamera = cvToEigen(eyeInHandTransformation);

--- a/source/Applications/Advanced/HandEyeCalibration/UtilizeEyeInHandCalibration/UtilizeEyeInHandCalibration.cpp
+++ b/source/Applications/Advanced/HandEyeCalibration/UtilizeEyeInHandCalibration/UtilizeEyeInHandCalibration.cpp
@@ -3,8 +3,10 @@ Utilize the result of eye-in-hand calibration to transform (picking) point
 coordinates from the camera frame to the robot base frame.
 */
 
-#include <Eigen/Core>
 #include <Zivid/Zivid.h>
+
+#include <Eigen/Core>
+
 #include <opencv2/core/core.hpp>
 
 #include <cmath>

--- a/source/Applications/Basic/FileFormats/ReadIterateZDF/ReadIterateZDF.cpp
+++ b/source/Applications/Basic/FileFormats/ReadIterateZDF/ReadIterateZDF.cpp
@@ -12,7 +12,7 @@ int main()
     {
         Zivid::Application zivid;
 
-        const std::string filename = "Zivid3D.zdf";
+        const auto filename = Zivid::Environment::dataPath() + "/Zivid3D.zdf";
         std::cout << "Reading " << filename << " point cloud" << std::endl;
         const Zivid::Frame frame = Zivid::Frame(filename);
 

--- a/source/Applications/Basic/Visualization/CaptureLiveVis3D/CaptureLiveVis3D.cpp
+++ b/source/Applications/Basic/Visualization/CaptureLiveVis3D/CaptureLiveVis3D.cpp
@@ -1,5 +1,6 @@
 #include <Zivid/CloudVisualizer.h>
 #include <Zivid/Zivid.h>
+
 #include <iostream>
 
 int main()

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -85,13 +85,6 @@ else()
     disable_samples("OpenCV")
 endif()
 
-add_custom_target(
-    CopyZdf
-    COMMAND ${CMAKE_COMMAND} -E copy
-            ${CMAKE_CURRENT_SOURCE_DIR}/Zivid3D.zdf
-            ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}
-)
-
 message(STATUS "All samples: ${SAMPLES}")
 
 foreach(SAMPLE ${SAMPLES})
@@ -122,33 +115,6 @@ foreach(SAMPLE ${SAMPLES})
         target_include_directories(${SAMPLE_NAME} SYSTEM PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/3rd-party/clipp/include)
     endif()
 
-    add_dependencies(${SAMPLE_NAME} CopyZdf)
-
 endforeach()
-
-# TODO: Generalize how input file dependencies are copied, see issue #46
-add_custom_target(
-    CopyHandEyeFiles
-    COMMAND ${CMAKE_COMMAND} -E copy
-            ${CMAKE_CURRENT_SOURCE_DIR}/Applications/Advanced/HandEyeCalibration/robotTransform.yaml
-            ${CMAKE_CURRENT_SOURCE_DIR}/Applications/Advanced/HandEyeCalibration/handEyeTransform.yaml
-            ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}
-)
-if(TARGET UtilizeEyeInHandCalibration)
-    add_dependencies("UtilizeEyeInHandCalibration" CopyHandEyeFiles)
-endif()
-if(TARGET PoseConversions)
-    add_dependencies("PoseConversions" CopyHandEyeFiles)
-endif()
-
-add_custom_target(
-    CopyCameraSettings
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-            ${CMAKE_CURRENT_SOURCE_DIR}/Settings/
-            ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/Settings
-)
-if(TARGET CaptureHDRLoop)
-    add_dependencies("CaptureHDRLoop" CopyCameraSettings)
-endif()
 
 target_compile_definitions(ZividBenchmark PRIVATE OS_NAME=\"${CMAKE_SYSTEM_NAME}\")

--- a/source/Camera/Basic/Capture/Capture.cpp
+++ b/source/Camera/Basic/Capture/Capture.cpp
@@ -9,7 +9,7 @@ int main()
     {
         Zivid::Application zivid;
 
-        const auto *resultFile = "result.zdf";
+        const auto *resultFile = "Result.zdf";
 
         std::cout << "Connecting to camera" << std::endl;
         auto camera = zivid.connectCamera();

--- a/source/Camera/Basic/Capture2D/Capture2D.cpp
+++ b/source/Camera/Basic/Capture2D/Capture2D.cpp
@@ -29,7 +29,7 @@ int main()
         std::cout << "Pixel color: R=" << static_cast<int>(pixel.r) << ", G=" << static_cast<int>(pixel.g)
                   << ", B=" << static_cast<int>(pixel.b) << ", A=" << static_cast<int>(pixel.a) << std::endl;
 
-        const auto *resultFile = "result.png";
+        const auto *resultFile = "Image.png";
         std::cout << "Saving the image to " << resultFile << std::endl;
         image.save(resultFile);
     }

--- a/source/Camera/Basic/CaptureAssistant/CaptureAssistant.cpp
+++ b/source/Camera/Basic/CaptureAssistant/CaptureAssistant.cpp
@@ -14,7 +14,7 @@ int main()
         std::cout << "Connecting to camera" << std::endl;
         auto camera{ zivid.connectCamera() };
 
-        const auto *resultFile = "result.zdf";
+        const auto *resultFile = "Result.zdf";
         Zivid::CaptureAssistant::SuggestSettingsParameters suggestSettingsParameters(
             std::chrono::milliseconds{ 1200 }, Zivid::CaptureAssistant::AmbientLightFrequency::none);
 

--- a/source/Camera/Basic/CaptureFromFile/CaptureFromFile.cpp
+++ b/source/Camera/Basic/CaptureFromFile/CaptureFromFile.cpp
@@ -11,7 +11,7 @@ int main()
         Zivid::Application zivid;
 
         auto zdfFile = Zivid::Environment::dataPath() + "/MiscObjects.zdf";
-        const auto *resultFile = "result.zdf";
+        const auto *resultFile = "Result.zdf";
 
         std::cout << "Initializing camera emulation using file: " << zdfFile << std::endl;
         auto camera = zivid.createFileCamera(zdfFile);

--- a/source/Camera/Basic/CaptureFromFile/CaptureFromFile.cpp
+++ b/source/Camera/Basic/CaptureFromFile/CaptureFromFile.cpp
@@ -2,6 +2,7 @@
 // Latest version of Zivid software (including samples) can be found at http://zivid.com/software/.
 
 #include <Zivid/Zivid.h>
+
 #include <iostream>
 
 int main()

--- a/source/Camera/Basic/CaptureHDRLoop/CaptureHDRLoop.cpp
+++ b/source/Camera/Basic/CaptureHDRLoop/CaptureHDRLoop.cpp
@@ -1,6 +1,5 @@
 /*
-This example shows how to acquire HDR images from the Zivid camera in a loop,
-with settings from .yml files.
+This example shows how to acquire HDR images from the Zivid camera in a loop, with settings from files.
 */
 
 #include <Zivid/Zivid.h>
@@ -26,7 +25,7 @@ int main()
             for(size_t frame = 1; frame <= framesPerCapture; frame++)
             {
                 std::stringstream settingsPath;
-                settingsPath << "Settings/set" << set << "/frame_0" << frame << ".yml";
+                settingsPath << Zivid::Environment::dataPath() + "/Settings/Set" << set << "/Frame0" << frame << ".yml";
                 std::cout << "Add settings from " << settingsPath.str() << ":" << std::endl;
                 const auto setting = Zivid::Settings(settingsPath.str());
                 std::cout << setting.toString() << std::endl;

--- a/source/Camera/Basic/CaptureTutorial.md
+++ b/source/Camera/Basic/CaptureTutorial.md
@@ -158,11 +158,11 @@ settings2D.set(Zivid::Settings2D::Brightness{ 1.0 });
 
 Zivid Studio can store the current settings to .yml files. These can be read and applied in the API. You may find it easier to modify the settings in these (human-readable) yaml-files in your preferred editor.
 ```cpp
-camera.setSettings(Zivid::Settings("frame_01.yml"));
+camera.setSettings(Zivid::Settings("Frame01.yml"));
 ```
 You may also apply settings from file while connecting to the camera.
 ```cpp
-auto camera = zivid.connectCamera(Zivid::Settings("frame_01.yml"));
+auto camera = zivid.connectCamera(Zivid::Settings("Frame01.yml"));
 ```
 
 ## Capture
@@ -191,7 +191,7 @@ auto frame2D = camera.capture2D(settings2D);
 
 We can now save our results ([go to source][save-url]).
 ```cpp
-frame.save("result.zdf");
+frame.save("Result.zdf");
 ```
 The API detects which format to use. See [Point Cloud][kb-point_cloud-url] for a list of supported formats.
 
@@ -199,7 +199,7 @@ The API detects which format to use. See [Point Cloud][kb-point_cloud-url] for a
 
 If we captured a 2D image, we can save it ([go to source][save2d-url]).
 ```cpp
-frame2D.save("result.png");
+frame2D.save("Result.png");
 ```
 
 ## Conclusion

--- a/source/Camera/Basic/QuickCaptureTutorial.md
+++ b/source/Camera/Basic/QuickCaptureTutorial.md
@@ -33,7 +33,7 @@ auto frame = camera.capture();
 
 We can now save our results. By default the 3D point cloud is saved in Zivid format `.zdf` ([go to source][save-url]).
 ```cpp
-auto resultFile = "result.zdf";
+auto resultFile = "Result.zdf";
 frame.save(resultFile);
 ```
 

--- a/source/Camera/InfoUtilOther/GetCameraIntrinsics/GetCameraIntrinsics.cpp
+++ b/source/Camera/InfoUtilOther/GetCameraIntrinsics/GetCameraIntrinsics.cpp
@@ -19,7 +19,7 @@ int main()
 
         auto intrinsics = camera.intrinsics();
 
-        std::string fileNameIntrinsics = "intrinsics.yml";
+        std::string fileNameIntrinsics = "Intrinsics.yml";
         std::cout << "Saving camera intrinsics to " << fileNameIntrinsics << std::endl;
         intrinsics.save(fileNameIntrinsics);
 

--- a/source/Camera/InfoUtilOther/ZividBenchmark/ZividBenchmark.cpp
+++ b/source/Camera/InfoUtilOther/ZividBenchmark/ZividBenchmark.cpp
@@ -1,4 +1,5 @@
 #include <Zivid/Zivid.h>
+
 #include <algorithm>
 #include <iostream>
 


### PR DESCRIPTION
We've agreed to stop duplicating sample data in each repository. Instead we will host all sample data on webpage/downloads/ZividSampleData.zip.